### PR TITLE
Add solidity linter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,13 @@
+{
+  "extends": "default",
+  "rules": {
+    "bracket-align": "warn",
+    "code-complexity": "warn",
+    "const-name-snakecase": "warn",
+    "expression-indent": "warn",
+    "function-max-lines": "warn",
+    "indent": "warn",
+    "max-line-length": "warn",
+    "statement-indent": "warn"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "networks": "truffle networks",
     "test-norpc": "truffle test --network testing",
     "test": "run-with-testrpc -l 20000000 'truffle test --network testing'",
+    "lint-contracts": "solhint contracts/**/*.sol",
     "coverage": "solidity-coverage",
     "injectnetinfo": "node scripts/inject_network_info.js",
     "extractnetinfo": "node scripts/extract_network_info.js",
@@ -35,6 +36,7 @@
     "lodash": "^4.17.4",
     "npm-prepublish": "^1.2.3",
     "run-with-testrpc": "^0.3.0",
+    "solhint": "^1.1.10",
     "solidity-coverage": "^0.4.2",
     "solmd": "github:cag/solmd",
     "truffle": "^3.4.11"


### PR DESCRIPTION
This adds Solhint to improve code quality and security on solidity contracts.

No modifications were made to the contracts, but the emitted warnings should help make the code comply with the [style guide](http://solidity.readthedocs.io/en/develop/style-guide.html).