### PR TITLE
Update to Solidity v0.5 and Truffle v5.0 - 'v1' branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
 - 'node'
-- '8'
-- '7'
+- '10'
+- '9'
 before_install:
 - npm install -g npm codecov greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
@@ -16,5 +16,5 @@ deploy:
   on:
     all_branches: true
     tags: true
-    node: '8'
+    node: '10'
     repo: gnosis/pm-contracts

--- a/contracts/Events/CategoricalEvent.sol
+++ b/contracts/Events/CategoricalEvent.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Events/Event.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
@@ -14,12 +14,12 @@ contract CategoricalEventProxy is Proxy, EventData {
         public
     {
         // Validate input
-        require(address(_collateralToken) != 0 && address(_oracle) != 0 && outcomeCount >= 2);
+        require(address(_collateralToken) != address(0) && address(_oracle) != address(0) && outcomeCount >= 2);
         collateralToken = _collateralToken;
         oracle = _oracle;
         // Create an outcome token for each outcome
         for (uint8 i = 0; i < outcomeCount; i++) {
-            OutcomeToken outcomeToken = OutcomeToken(new OutcomeTokenProxy(outcomeTokenMasterCopy));
+            OutcomeToken outcomeToken = OutcomeToken(address(new OutcomeTokenProxy(outcomeTokenMasterCopy)));
             outcomeTokens.push(outcomeToken);
             emit OutcomeTokenCreation(outcomeToken, i);
         }

--- a/contracts/Events/Event.sol
+++ b/contracts/Events/Event.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "../Tokens/OutcomeToken.sol";
 import "../Oracles/Oracle.sol";
@@ -39,7 +39,7 @@ contract Event is EventData {
         public
     {
         // Transfer collateral tokens to events contract
-        require(collateralToken.transferFrom(msg.sender, this, collateralTokenCount));
+        require(collateralToken.transferFrom(msg.sender, address(this), collateralTokenCount));
         // Issue new outcome tokens to sender
         for (uint8 i = 0; i < outcomeTokens.length; i++)
             outcomeTokens[i].issue(msg.sender, collateralTokenCount);
@@ -86,7 +86,7 @@ contract Event is EventData {
     function getOutcomeTokens()
         public
         view
-        returns (OutcomeToken[])
+        returns (OutcomeToken[] memory)
     {
         return outcomeTokens;
     }
@@ -96,7 +96,7 @@ contract Event is EventData {
     function getOutcomeTokenDistribution(address owner)
         public
         view
-        returns (uint[] outcomeTokenDistribution)
+        returns (uint[] memory outcomeTokenDistribution)
     {
         outcomeTokenDistribution = new uint[](outcomeTokens.length);
         for (uint8 i = 0; i < outcomeTokenDistribution.length; i++)

--- a/contracts/Events/EventFactory.sol
+++ b/contracts/Events/EventFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Events/CategoricalEvent.sol";
 import "../Events/ScalarEvent.sol";
 
@@ -52,15 +52,15 @@ contract EventFactory {
     {
         bytes32 eventHash = keccak256(abi.encodePacked(collateralToken, oracle, outcomeCount));
         // Event should not exist yet
-        require(address(categoricalEvents[eventHash]) == 0);
+        require(address(categoricalEvents[eventHash]) == address(0));
         // Create event
-        eventContract = CategoricalEvent(new CategoricalEventProxy(
-            categoricalEventMasterCopy,
-            outcomeTokenMasterCopy,
+        eventContract = CategoricalEvent(address(new CategoricalEventProxy(
+            address(categoricalEventMasterCopy),
+            address(outcomeTokenMasterCopy),
             collateralToken,
             oracle,
             outcomeCount
-        ));
+        )));
         categoricalEvents[eventHash] = eventContract;
         emit CategoricalEventCreation(msg.sender, eventContract, collateralToken, oracle, outcomeCount);
     }
@@ -82,16 +82,16 @@ contract EventFactory {
     {
         bytes32 eventHash = keccak256(abi.encodePacked(collateralToken, oracle, lowerBound, upperBound));
         // Event should not exist yet
-        require(address(scalarEvents[eventHash]) == 0);
+        require(address(scalarEvents[eventHash]) == address(0));
         // Create event
-        eventContract = ScalarEvent(new ScalarEventProxy(
-            scalarEventMasterCopy,
-            outcomeTokenMasterCopy,
+        eventContract = ScalarEvent(address(new ScalarEventProxy(
+            address(scalarEventMasterCopy),
+            address(outcomeTokenMasterCopy),
             collateralToken,
             oracle,
             lowerBound,
             upperBound
-        ));
+        )));
         scalarEvents[eventHash] = eventContract;
         emit ScalarEventCreation(msg.sender, eventContract, collateralToken, oracle, lowerBound, upperBound);
     }

--- a/contracts/Events/ScalarEvent.sol
+++ b/contracts/Events/ScalarEvent.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Events/Event.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
@@ -38,12 +38,12 @@ contract ScalarEventProxy is Proxy, EventData, ScalarEventData {
         public
     {
         // Validate input
-        require(address(_collateralToken) != 0 && address(_oracle) != 0);
+        require(address(_collateralToken) != address(0) && address(_oracle) != address(0));
         collateralToken = _collateralToken;
         oracle = _oracle;
         // Create an outcome token for each outcome
         for (uint8 i = 0; i < 2; i++) {
-            OutcomeToken outcomeToken = OutcomeToken(new OutcomeTokenProxy(outcomeTokenMasterCopy));
+            OutcomeToken outcomeToken = OutcomeToken(address(new OutcomeTokenProxy(outcomeTokenMasterCopy)));
             outcomeTokens.push(outcomeToken);
             emit OutcomeTokenCreation(outcomeToken, i);
         }

--- a/contracts/MarketMakers/LMSRMarketMaker.sol
+++ b/contracts/MarketMakers/LMSRMarketMaker.sol
@@ -1,5 +1,6 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 import "@gnosis.pm/util-contracts/contracts/Fixed192x64Math.sol";
 import "../MarketMakers/MarketMaker.sol";
 
@@ -7,7 +8,8 @@ import "../MarketMakers/MarketMaker.sol";
 /// @title LMSR market maker contract - Calculates share prices based on share distribution and initial funding
 /// @author Alan Lu - <alan.lu@gnosis.pm>
 contract LMSRMarketMaker is MarketMaker {
-    using SafeMath for *;
+    using SignedSafeMath for int;
+    using SafeMath for uint;
 
     /*
      *  Constants
@@ -22,7 +24,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param market Market contract
     /// @param outcomeTokenAmounts Amounts of outcome tokens to buy from the market. If an amount is negative, represents an amount to sell to the market.
     /// @return Net cost of trade. If positive, represents amount of collateral which would be paid to the market for the trade. If negative, represents amount of collateral which would be received from the market for the trade.
-    function calcNetCost(Market market, int[] outcomeTokenAmounts)
+    function calcNetCost(Market market, int[] memory outcomeTokenAmounts)
         public
         view
         returns (int netCost)
@@ -148,7 +150,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param netOutcomeTokensSold Net outcome tokens sold by market
     /// @param funding Initial funding for market
     /// @return Cost level
-    function calcCostLevel(int logN, int[] netOutcomeTokensSold, uint funding, Fixed192x64Math.EstimationMode estimationMode)
+    function calcCostLevel(int logN, int[] memory netOutcomeTokensSold, uint funding, Fixed192x64Math.EstimationMode estimationMode)
         private
         pure
         returns(int costLevel)
@@ -169,7 +171,7 @@ contract LMSRMarketMaker is MarketMaker {
     /// @param funding Initial funding for market
     /// @param outcomeIndex Index of exponential term to extract (for use by marginal price function)
     /// @return A result structure composed of the sum, the offset used, and the summand associated with the supplied index
-    function sumExpOffset(int logN, int[] netOutcomeTokensSold, uint funding, uint8 outcomeIndex, Fixed192x64Math.EstimationMode estimationMode)
+    function sumExpOffset(int logN, int[] memory netOutcomeTokensSold, uint funding, uint8 outcomeIndex, Fixed192x64Math.EstimationMode estimationMode)
         private
         pure
         returns (uint sum, int offset, uint outcomeExpTerm)
@@ -211,7 +213,7 @@ contract LMSRMarketMaker is MarketMaker {
     function getNetOutcomeTokensSold(Market market)
         private
         view
-        returns (int[] quantities)
+        returns (int[] memory quantities)
     {
         quantities = new int[](market.eventContract().getOutcomeCount());
         for (uint8 i = 0; i < quantities.length; i++)

--- a/contracts/MarketMakers/MarketMaker.sol
+++ b/contracts/MarketMakers/MarketMaker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Markets/Market.sol";
 
 
@@ -10,6 +10,6 @@ contract MarketMaker {
      */
     function calcCost(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public view returns (uint);
     function calcProfit(Market market, uint8 outcomeTokenIndex, uint outcomeTokenCount) public view returns (uint);
-    function calcNetCost(Market market, int[] outcomeTokenAmounts) public view returns (int);
+    function calcNetCost(Market market, int[] memory outcomeTokenAmounts) public view returns (int);
     function calcMarginalPrice(Market market, uint8 outcomeTokenIndex) public view returns (uint);
 }

--- a/contracts/Markets/CampaignFactory.sol
+++ b/contracts/Markets/CampaignFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Markets/Campaign.sol";
 
 
@@ -44,8 +44,8 @@ contract CampaignFactory {
         public
         returns (Campaign campaign)
     {
-        campaign = Campaign(new CampaignProxy(
-            campaignMasterCopy, eventContract, marketFactory, marketMaker, fee, funding, deadline));
+        campaign = Campaign(address(new CampaignProxy(
+            address(campaignMasterCopy), eventContract, marketFactory, marketMaker, fee, funding, deadline)));
         emit CampaignCreation(msg.sender, campaign, eventContract, marketFactory, marketMaker, fee, funding, deadline);
     }
 }

--- a/contracts/Markets/Market.sol
+++ b/contracts/Markets/Market.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Events/Event.sol";
 import "../MarketMakers/MarketMaker.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
@@ -46,6 +46,6 @@ contract Market is MarketData {
     function buy(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint maxCost) public returns (uint);
     function sell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
     function shortSell(uint8 outcomeTokenIndex, uint outcomeTokenCount, uint minProfit) public returns (uint);
-    function trade(int[] outcomeTokenAmounts, int costLimit) public returns (int);
+    function trade(int[] memory outcomeTokenAmounts, int costLimit) public returns (int);
     function calcMarketFee(uint outcomeTokenCost) public view returns (uint);
 }

--- a/contracts/Markets/StandardMarketFactory.sol
+++ b/contracts/Markets/StandardMarketFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Markets/StandardMarket.sol";
 
 
@@ -32,7 +32,7 @@ contract StandardMarketFactory {
         public
         returns (StandardMarket market)
     {
-        market = StandardMarket(new StandardMarketProxy(standardMarketMasterCopy, msg.sender, eventContract, marketMaker, fee));
+        market = StandardMarket(address(new StandardMarketProxy(address(standardMarketMasterCopy), msg.sender, eventContract, marketMaker, fee)));
         emit StandardMarketCreation(msg.sender, market, eventContract, marketMaker, fee);
     }
 }

--- a/contracts/Markets/StandardMarketWithPriceLogger.sol
+++ b/contracts/Markets/StandardMarketWithPriceLogger.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Markets/StandardMarket.sol";
 
 contract StandardMarketWithPriceLoggerData {
@@ -98,7 +98,7 @@ contract StandardMarketWithPriceLogger is StandardMarket, StandardMarketWithPric
     /// @param outcomeTokenAmounts Amounts of outcome tokens to trade
     /// @param collateralLimit The maximum cost or minimum profit in collateral tokens
     /// @return Cost/profit in collateral tokens
-    function trade(int[] outcomeTokenAmounts, int collateralLimit)
+    function trade(int[] memory outcomeTokenAmounts, int collateralLimit)
         public
         returns (int netCost)
     {

--- a/contracts/Markets/StandardMarketWithPriceLoggerFactory.sol
+++ b/contracts/Markets/StandardMarketWithPriceLoggerFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Markets/StandardMarketWithPriceLogger.sol";
 
 
@@ -35,8 +35,8 @@ contract StandardMarketWithPriceLoggerFactory {
         public
         returns (StandardMarketWithPriceLogger market)
     {
-        market = StandardMarketWithPriceLogger(new StandardMarketWithPriceLoggerProxy(
-            standardMarketWithPriceLoggerMasterCopy, msg.sender, eventContract, marketMaker, fee, startDate));
+        market = StandardMarketWithPriceLogger(address(new StandardMarketWithPriceLoggerProxy(
+            address(standardMarketWithPriceLoggerMasterCopy), msg.sender, eventContract, marketMaker, fee, startDate)));
         emit StandardMarketWithPriceLoggerCreation(msg.sender, market, eventContract, marketMaker, fee, startDate);
     }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,6 +1,6 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "canonical-weth/contracts/WETH9.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
 contract Migrations {
     address public owner;

--- a/contracts/Oracles/CentralizedOracle.sol
+++ b/contracts/Oracles/CentralizedOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
@@ -33,7 +33,7 @@ contract CentralizedOracleProxy is Proxy, CentralizedOracleData {
 
     /// @dev Constructor sets owner address and IPFS hash
     /// @param _ipfsHash Hash identifying off chain event description
-    constructor(address proxied, address _owner, bytes _ipfsHash)
+    constructor(address proxied, address _owner, bytes memory _ipfsHash)
         public
         Proxy(proxied)
     {

--- a/contracts/Oracles/CentralizedOracleFactory.sol
+++ b/contracts/Oracles/CentralizedOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/CentralizedOracle.sol";
 
 
@@ -28,11 +28,11 @@ contract CentralizedOracleFactory {
     /// @dev Creates a new centralized oracle contract
     /// @param ipfsHash Hash identifying off chain event description
     /// @return Oracle contract
-    function createCentralizedOracle(bytes ipfsHash)
+    function createCentralizedOracle(bytes memory ipfsHash)
         public
         returns (CentralizedOracle centralizedOracle)
     {
-        centralizedOracle = CentralizedOracle(new CentralizedOracleProxy(centralizedOracleMasterCopy, msg.sender, ipfsHash));
+        centralizedOracle = CentralizedOracle(address(new CentralizedOracleProxy(address(centralizedOracleMasterCopy), msg.sender, ipfsHash)));
         emit CentralizedOracleCreation(msg.sender, centralizedOracle, ipfsHash);
     }
 }

--- a/contracts/Oracles/DifficultyOracle.sol
+++ b/contracts/Oracles/DifficultyOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 
 

--- a/contracts/Oracles/DifficultyOracleFactory.sol
+++ b/contracts/Oracles/DifficultyOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/DifficultyOracle.sol";
 
 

--- a/contracts/Oracles/FutarchyOracle.sol
+++ b/contracts/Oracles/FutarchyOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 import "../Events/EventFactory.sol";
 import "../Markets/StandardMarketWithPriceLoggerFactory.sol";
@@ -75,7 +75,7 @@ contract FutarchyOracleProxy is Proxy, FutarchyOracleData {
         // trading period is at least a second
         require(_tradingPeriod > 0);
         // Create decision event
-        categoricalEvent = eventFactory.createCategoricalEvent(collateralToken, Oracle(this), outcomeCount);
+        categoricalEvent = eventFactory.createCategoricalEvent(collateralToken, Oracle(address(this)), outcomeCount);
         // Create outcome events
         for (uint8 i = 0; i < categoricalEvent.getOutcomeCount(); i++) {
             ScalarEvent scalarEvent = eventFactory.createScalarEvent(
@@ -106,14 +106,14 @@ contract FutarchyOracle is Proxied, Oracle, FutarchyOracleData {
         isCreator
     {
         // Buy all outcomes
-        require(   categoricalEvent.collateralToken().transferFrom(creator, this, funding)
-                && categoricalEvent.collateralToken().approve(categoricalEvent, funding));
+        require(   categoricalEvent.collateralToken().transferFrom(creator, address(this), funding)
+                && categoricalEvent.collateralToken().approve(address(categoricalEvent), funding));
         categoricalEvent.buyAllOutcomes(funding);
         // Fund each market with outcome tokens from categorical event
         for (uint8 i = 0; i < markets.length; i++) {
             Market market = markets[i];
             // Approve funding for market
-            require(market.eventContract().collateralToken().approve(market, funding));
+            require(market.eventContract().collateralToken().approve(address(market), funding));
             market.fund(funding);
         }
         emit FutarchyFunding(funding);
@@ -133,7 +133,7 @@ contract FutarchyOracle is Proxied, Oracle, FutarchyOracleData {
         market.withdrawFees();
         // Redeem collateral token for winning outcome tokens and transfer collateral tokens to creator
         categoricalEvent.redeemWinnings();
-        require(categoricalEvent.collateralToken().transfer(creator, categoricalEvent.collateralToken().balanceOf(this)));
+        require(categoricalEvent.collateralToken().transfer(creator, categoricalEvent.collateralToken().balanceOf(address(this))));
         emit FutarchyClosing();
     }
 

--- a/contracts/Oracles/FutarchyOracleFactory.sol
+++ b/contracts/Oracles/FutarchyOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/FutarchyOracle.sol";
 
 
@@ -39,7 +39,7 @@ contract FutarchyOracleFactory {
     constructor(FutarchyOracle _futarchyOracleMasterCopy, EventFactory _eventFactory, StandardMarketWithPriceLoggerFactory _marketFactory)
         public
     {
-        require(address(_eventFactory) != 0 && address(_marketFactory) != 0);
+        require(address(_eventFactory) != address(0) && address(_marketFactory) != address(0));
         futarchyOracleMasterCopy = _futarchyOracleMasterCopy;
         eventFactory = _eventFactory;
         marketFactory = _marketFactory;
@@ -70,8 +70,8 @@ contract FutarchyOracleFactory {
         public
         returns (FutarchyOracle futarchyOracle)
     {
-        futarchyOracle = FutarchyOracle(new FutarchyOracleProxy(
-            futarchyOracleMasterCopy,
+        futarchyOracle = FutarchyOracle(address(new FutarchyOracleProxy(
+            address(futarchyOracleMasterCopy),
             msg.sender,
             eventFactory,
             collateralToken,
@@ -84,7 +84,7 @@ contract FutarchyOracleFactory {
             fee,
             tradingPeriod,
             startDate
-        ));
+        )));
         emit FutarchyOracleCreation(
             msg.sender,
             futarchyOracle,

--- a/contracts/Oracles/MajorityOracle.sol
+++ b/contracts/Oracles/MajorityOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
@@ -15,7 +15,7 @@ contract MajorityOracleProxy is Proxy, MajorityOracleData {
 
     /// @dev Allows to create an oracle for a majority vote based on other oracles
     /// @param _oracles List of oracles taking part in the majority vote
-    constructor(address proxied, Oracle[] _oracles)
+    constructor(address proxied, Oracle[] memory _oracles)
         Proxy(proxied)
         public
     {
@@ -23,7 +23,7 @@ contract MajorityOracleProxy is Proxy, MajorityOracleData {
         require(_oracles.length > 2);
         for (uint i = 0; i < _oracles.length; i++)
             // Oracle address cannot be null
-            require(address(_oracles[i]) != 0);
+            require(address(_oracles[i]) != address(0));
         oracles = _oracles;
     }
 }

--- a/contracts/Oracles/MajorityOracleFactory.sol
+++ b/contracts/Oracles/MajorityOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/MajorityOracle.sol";
 
 
@@ -28,11 +28,11 @@ contract MajorityOracleFactory {
     /// @dev Creates a new majority oracle contract
     /// @param oracles List of oracles taking part in the majority vote
     /// @return Oracle contract
-    function createMajorityOracle(Oracle[] oracles)
+    function createMajorityOracle(Oracle[] memory oracles)
         public
         returns (MajorityOracle majorityOracle)
     {
-        majorityOracle = MajorityOracle(new MajorityOracleProxy(majorityOracleMasterCopy, oracles));
+        majorityOracle = MajorityOracle(address(new MajorityOracleProxy(address(majorityOracleMasterCopy), oracles)));
         emit MajorityOracleCreation(msg.sender, majorityOracle, oracles);
     }
 }

--- a/contracts/Oracles/Oracle.sol
+++ b/contracts/Oracles/Oracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 /// @title Abstract oracle contract - Functions to be implemented by oracles

--- a/contracts/Oracles/SignedMessageOracle.sol
+++ b/contracts/Oracles/SignedMessageOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 

--- a/contracts/Oracles/SignedMessageOracleFactory.sol
+++ b/contracts/Oracles/SignedMessageOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/SignedMessageOracle.sol";
 
 
@@ -35,7 +35,7 @@ contract SignedMessageOracleFactory {
         public
         returns (SignedMessageOracle signedMessageOracle)
     {
-        signedMessageOracle = SignedMessageOracle(new SignedMessageOracleProxy(signedMessageOracleMasterCopy, descriptionHash, v, r, s));
+        signedMessageOracle = SignedMessageOracle(address(new SignedMessageOracleProxy(address(signedMessageOracleMasterCopy), descriptionHash, v, r, s)));
         address oracle = ecrecover(descriptionHash, v, r, s);
         emit SignedMessageOracleCreation(msg.sender, signedMessageOracle, oracle);
     }

--- a/contracts/Oracles/UltimateOracle.sol
+++ b/contracts/Oracles/UltimateOracle.sol
@@ -1,7 +1,8 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/Oracle.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 
@@ -57,8 +58,8 @@ contract UltimateOracleProxy is Proxy, UltimateOracleData {
         public
     {
         // Validate inputs
-        require(   address(_forwardedOracle) != 0
-                && address(_collateralToken) != 0
+        require(   address(_forwardedOracle) != address(0)
+                && address(_collateralToken) != address(0)
                 && _spreadMultiplier >= 2
                 && _challengePeriod > 0
                 && _challengeAmount > 0
@@ -75,7 +76,8 @@ contract UltimateOracleProxy is Proxy, UltimateOracleData {
 /// @title Ultimate oracle contract - Allows to swap oracle result for ultimate oracle result
 /// @author Stefan George - <stefan@gnosis.pm>
 contract UltimateOracle is Proxied, Oracle, UltimateOracleData {
-    using SafeMath for *;
+    using SignedSafeMath for int;
+    using SafeMath for uint;
 
     /*
      *  Public functions
@@ -101,7 +103,7 @@ contract UltimateOracle is Proxied, Oracle, UltimateOracleData {
         // There was no challenge yet or the challenge period expired
         require(   !isChallenged()
                 && !isChallengePeriodOver()
-                && collateralToken.transferFrom(msg.sender, this, challengeAmount));
+                && collateralToken.transferFrom(msg.sender, address(this), challengeAmount));
         outcomeAmounts[msg.sender][_outcome] = challengeAmount;
         totalOutcomeAmounts[_outcome] = challengeAmount;
         totalAmount = challengeAmount;
@@ -128,7 +130,7 @@ contract UltimateOracle is Proxied, Oracle, UltimateOracleData {
         // Outcome is challenged and front runner period is not over yet and tokens can be transferred
         require(   isChallenged()
                 && !isFrontRunnerPeriodOver()
-                && collateralToken.transferFrom(msg.sender, this, amount));
+                && collateralToken.transferFrom(msg.sender, address(this), amount));
         outcomeAmounts[msg.sender][_outcome] = outcomeAmounts[msg.sender][_outcome].add(amount);
         totalOutcomeAmounts[_outcome] = totalOutcomeAmounts[_outcome].add(amount);
         totalAmount = totalAmount.add(amount);

--- a/contracts/Oracles/UltimateOracleFactory.sol
+++ b/contracts/Oracles/UltimateOracleFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 import "../Oracles/UltimateOracle.sol";
 
 
@@ -53,15 +53,15 @@ contract UltimateOracleFactory {
         public
         returns (UltimateOracle ultimateOracle)
     {
-        ultimateOracle = UltimateOracle(new UltimateOracleProxy(
-            ultimateOracleMasterCopy,
+        ultimateOracle = UltimateOracle(address(new UltimateOracleProxy(
+            address(ultimateOracleMasterCopy),
             oracle,
             collateralToken,
             spreadMultiplier,
             challengePeriod,
             challengeAmount,
             frontRunnerPeriod
-        ));
+        )));
         emit UltimateOracleCreation(
             msg.sender,
             ultimateOracle,

--- a/contracts/Tokens/OutcomeToken.sol
+++ b/contracts/Tokens/OutcomeToken.sol
@@ -1,5 +1,5 @@
-pragma solidity ^0.4.24;
-import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+pragma solidity ^0.5.0;
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
 
@@ -29,7 +29,7 @@ contract OutcomeTokenProxy is Proxy {
 
 /// @title Outcome token contract - Issuing and revoking outcome tokens
 /// @author Stefan George - <stefan@gnosis.pm>
-contract OutcomeToken is Proxied, StandardToken {
+contract OutcomeToken is Proxied, ERC20 {
     using SafeMath for *;
 
     /*
@@ -62,8 +62,7 @@ contract OutcomeToken is Proxied, StandardToken {
         public
         isEventContract
     {
-        balances[_for] = balances[_for].add(outcomeTokenCount);
-        totalSupply_ = totalSupply_.add(outcomeTokenCount);
+        _mint(_for, outcomeTokenCount);
         emit Issuance(_for, outcomeTokenCount);
     }
 
@@ -74,8 +73,7 @@ contract OutcomeToken is Proxied, StandardToken {
         public
         isEventContract
     {
-        balances[_for] = balances[_for].sub(outcomeTokenCount);
-        totalSupply_ = totalSupply_.sub(outcomeTokenCount);
+        _burn(_for, outcomeTokenCount);
         emit Revocation(_for, outcomeTokenCount);
     }
 }

--- a/ensurebc.js
+++ b/ensurebc.js
@@ -5,7 +5,7 @@ const artifactsDir = path.join('build', 'contracts')
 
 for(const [newName, bcName] of [
     ['ERC20', 'Token'],
-    ['DetailedERC20', 'HumanFriendlyToken'],
+    ['ERC20Detailed', 'HumanFriendlyToken'],
     ['WETH9', 'EtherToken'],
     ['Fixed192x64Math', 'Math'],
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,15 @@
       "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
@@ -153,14 +162,23 @@
       }
     },
     "@gnosis.pm/util-contracts": {
-      "version": "2.0.0-alpha",
-      "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-2.0.0-alpha.tgz",
-      "integrity": "sha512-eR4Q5WjE9nHznvpzx6mBPAfHf47+9PWLyPeIdx6hFjEAi+a4EZwxKfZbTC1Qs/is3x4qiBJxSq6fEtPgNYM3ng=="
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@gnosis.pm/util-contracts/-/util-contracts-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-9rvTRON3UWDVlSzP0+JmZtKNImMitDrRBfynHCbAlLT5iiy9omk9RbGSY3Zw3XxSvZPLRTI7+mhzv+L+DGjuyA=="
+    },
+    "@types/bn.js": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
+      "integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
-      "version": "10.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
-      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
+      "version": "10.14.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
       "dev": true
     },
     "abi-decoder": {
@@ -183,6 +201,13 @@
             "utf8": "^2.1.1",
             "xhr2": "*",
             "xmlhttprequest": "*"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+              "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+              "dev": true
+            }
           }
         }
       }
@@ -219,15 +244,15 @@
       "dev": true
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -257,10 +282,10 @@
       "integrity": "sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==",
       "dev": true
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+    "app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
       "dev": true
     },
     "argparse": {
@@ -391,9 +416,18 @@
       }
     },
     "bignumber.js": {
-      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "dev": true
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.2",
@@ -405,19 +439,10 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
       "dev": true
     },
     "bn.js": {
@@ -514,12 +539,13 @@
       }
     },
     "browserify-sha3": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
-      "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
+      "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
       "dev": true,
       "requires": {
-        "js-sha3": "^0.3.1"
+        "js-sha3": "^0.6.1",
+        "safe-buffer": "^5.1.1"
       }
     },
     "browserify-sign": {
@@ -587,12 +613,6 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -615,15 +635,15 @@
       "dev": true
     },
     "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "canonical-weth": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/canonical-weth/-/canonical-weth-1.2.0.tgz",
-      "integrity": "sha512-3iodn+8KJg2qgUWNmOnsu8HbmIkEa/1TRkTQgl2l6N8duSUwk7M1TGP1RTBPJMuJpXStkTTOYnfC8b3ZigiUnw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/canonical-weth/-/canonical-weth-1.4.0.tgz",
+      "integrity": "sha512-9rkLfAFndWALLhxd5lpyTX4RkV36WmVBZ92NYtYr1kWdAUmclRp7I5KkK4wvogzDcCI++yw53TLwx/GCPcocMg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -646,6 +666,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
     "cipher-base": {
@@ -686,63 +712,20 @@
       "dev": true
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
         "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
@@ -780,6 +763,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "command-exists": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+      "dev": true
     },
     "commander": {
       "version": "2.8.1",
@@ -833,9 +822,9 @@
       "dev": true
     },
     "cors": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "requires": {
         "object-assign": "^4",
@@ -958,9 +947,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.1.tgz",
-      "integrity": "sha512-vklWB5C4Cj423xnaOtsUmAv0/7GqlXIgDv2ZKDyR64OV3OSzGHNx2mk4p/1EKnB5s70k73cIOOEcG9YzF0q4Lw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
+      "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg==",
       "dev": true
     },
     "decode-uri-component": {
@@ -1080,6 +1069,15 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "del": {
@@ -1228,13 +1226,29 @@
         "once": "^1.4.0"
       }
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -1491,9 +1505,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
-      "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
+      "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
       "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
@@ -1502,7 +1516,7 @@
         "elliptic": "6.3.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.3",
+        "scrypt-js": "2.0.4",
         "setimmediate": "1.0.4",
         "uuid": "2.0.1",
         "xmlhttprequest": "1.8.0"
@@ -1569,9 +1583,9 @@
       }
     },
     "eventemitter3": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz",
-      "integrity": "sha1-R3hr2qCHyvext15zq8XH1UAVjNA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -1582,6 +1596,34 @@
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "express": {
@@ -1691,9 +1733,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-diff": {
@@ -1748,6 +1790,12 @@
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -1772,13 +1820,12 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1815,25 +1862,14 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "forwarded": {
@@ -1876,28 +1912,13 @@
         }
       }
     },
-    "fs-promise": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
-      "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "requires": {
-        "any-promise": "^1.3.0",
-        "fs-extra": "^2.0.0",
-        "mz": "^2.6.0",
-        "thenify-all": "^1.6.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
-          }
-        }
+        "minipass": "^2.2.1"
       }
     },
     "fs.realpath": {
@@ -1906,17 +1927,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2036,13 +2051,22 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -2055,6 +2079,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-to-string-tag-x": {
@@ -2077,9 +2107,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
-      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -2103,12 +2133,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -2120,12 +2144,6 @@
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
       }
-    },
-    "http-https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
-      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2165,9 +2183,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "ignore": {
@@ -2231,25 +2249,16 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -2318,6 +2327,15 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -2336,16 +2354,19 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-windows": {
@@ -2383,9 +2404,9 @@
       }
     },
     "js-sha3": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
-      "integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
+      "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
       "dev": true
     },
     "js-tokens": {
@@ -2423,9 +2444,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -2461,14 +2482,26 @@
         "verror": "1.10.0"
       }
     },
-    "keccakjs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
-      "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "dev": true,
       "requires": {
-        "browserify-sha3": "^0.0.1",
-        "sha3": "^1.1.0"
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "keccakjs": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
+      "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
+      "dev": true,
+      "requires": {
+        "browserify-sha3": "^0.0.4",
+        "sha3": "^1.2.2"
       }
     },
     "klaw": {
@@ -2499,29 +2532,20 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "log-symbols": {
@@ -2538,6 +2562,16 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "make-dir": {
       "version": "1.3.0",
@@ -2572,6 +2606,15 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "memorystream": {
       "version": "0.3.1",
@@ -2608,18 +2651,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "~1.38.0"
       }
     },
     "mimic-fn": {
@@ -2669,6 +2712,33 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
+    },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^2.2.1"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2761,15 +2831,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.7.0.tgz",
-      "integrity": "sha512-WlQNtUlzMRpvLHf8dqeUmNqfdPjGY29KrJF50Ldb4AcL+vQeR8QH3wQcFMgrhTwb1gHjZn9xggho+84tBskLgA==",
-      "dev": true
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.8.0.tgz",
+      "integrity": "sha512-Gwj4KnJOW15YeTJKO5frFd/WDO5Mc0zxXqL9oHx3+e9rBqW8EVARqQHSaIXznUdljrD6pvbNGW2ZGXKPEfYJfw==",
       "dev": true
     },
     "ms": {
@@ -2783,17 +2847,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
-      "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
     },
     "nan": {
       "version": "2.10.0",
@@ -2825,18 +2878,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
     "npm-prepublish": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/npm-prepublish/-/npm-prepublish-1.2.3.tgz",
@@ -2857,6 +2898,15 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -2895,14 +2945,11 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
-    "oboe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
-      "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
-      "dev": true,
-      "requires": {
-        "http-https": "^1.0.0"
-      }
+    "object-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2932,8 +2979,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "github:gnosis/openzeppelin-solidity#9bffca97df2231d73d538c15e762395af3b57276",
-      "from": "github:gnosis/openzeppelin-solidity#fix-signed-safemath"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz",
+      "integrity": "sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ=="
     },
     "optionator": {
       "version": "0.8.2",
@@ -2970,12 +3018,14 @@
       "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -2996,6 +3046,24 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
     "p-timeout": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
@@ -3005,17 +3073,24 @@
         "p-finally": "^1.0.0"
       }
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parse-asn1": {
-      "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "dev": true,
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-code-context": {
@@ -3026,22 +3101,13 @@
       "optional": true
     },
     "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
       "dev": true,
       "requires": {
-        "for-each": "^0.3.2",
-        "trim": "0.0.1"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.2.0"
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parseurl": {
@@ -3051,13 +3117,10 @@
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3082,17 +3145,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -3232,10 +3284,16 @@
         "ipaddr.js": "1.8.0"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "public-encrypt": {
@@ -3275,10 +3333,16 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "dev": true
+    },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
@@ -3318,27 +3382,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -3353,6 +3396,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3395,9 +3444,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -3415,6 +3464,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3491,9 +3546,9 @@
       }
     },
     "scrypt-js": {
-      "version": "2.0.3",
-      "resolved": "http://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
       "dev": true
     },
     "scrypt.js": {
@@ -3669,16 +3724,19 @@
       }
     },
     "solc": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.6.tgz",
+      "integrity": "sha512-BuvrLwOSAGEUbE4jffLBcO9Vm8OVgxImE5qFTHzjH2n+RqBHeqDDOY0gU4LvGWsA6ttjADJyRriF9Pp0vjIq2g==",
       "dev": true,
       "requires": {
+        "command-exists": "^1.2.8",
         "fs-extra": "^0.30.0",
+        "keccak": "^1.0.2",
         "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
+        "require-from-string": "^2.0.0",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -3692,6 +3750,15 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
           }
         }
       }
@@ -3735,38 +3802,6 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3774,9 +3809,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -3818,6 +3853,17 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3836,15 +3882,6 @@
         "ansi-regex": "^3.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -3853,6 +3890,12 @@
       "requires": {
         "is-natural-number": "^4.0.1"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -3879,34 +3922,43 @@
       }
     },
     "swarm-js": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
-      "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+      "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
         "buffer": "^5.0.5",
         "decompress": "^4.0.0",
         "eth-lib": "^0.1.26",
-        "fs-extra": "^2.1.2",
-        "fs-promise": "^2.0.0",
+        "fs-extra": "^4.0.2",
         "got": "^7.1.0",
         "mime-types": "^2.1.16",
         "mkdirp-promise": "^5.0.1",
         "mock-fs": "^4.1.0",
         "setimmediate": "^1.0.5",
-        "tar.gz": "^1.0.5",
+        "tar": "^4.0.2",
         "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -3950,14 +4002,26 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "tar-stream": {
@@ -3975,50 +4039,11 @@
         "xtend": "^4.0.0"
       }
     },
-    "tar.gz": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
-      "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^2.9.34",
-        "commander": "^2.8.1",
-        "fstream": "^1.0.8",
-        "mout": "^0.11.0",
-        "tar": "^2.1.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "dev": true,
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "dev": true,
-      "requires": {
-        "thenify": ">= 3.1.0 < 4"
-      }
     },
     "through": {
       "version": "2.3.8",
@@ -4063,12 +4088,6 @@
         "punycode": "^1.4.1"
       }
     },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -4076,14 +4095,44 @@
       "dev": true
     },
     "truffle": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
-      "integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.9.tgz",
+      "integrity": "sha512-Y+UZxpAugmnCeRBOBGr3SpHhZ9Avpsj9qM7gTNdl1RH7nImTmWBQkUk/IUSUllK+66TAL9EEp2IH7Ji4YFhzVQ==",
       "dev": true,
       "requires": {
+        "app-module-path": "^2.2.0",
         "mocha": "^4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.24"
+        "solc": "0.5.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "solc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.0.tgz",
+          "integrity": "sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^0.30.0",
+            "keccak": "^1.0.2",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^2.0.0",
+            "semver": "^5.5.0",
+            "yargs": "^11.0.0"
+          }
+        }
       }
     },
     "tslib": {
@@ -4142,39 +4191,14 @@
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
-      "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-          "dev": true
-        },
-        "buffer": {
-          "version": "3.6.0",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-          "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-          "dev": true,
-          "requires": {
-            "base64-js": "0.0.8",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          }
-        }
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
-    },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -4203,6 +4227,16 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {
@@ -4250,16 +4284,6 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4296,155 +4320,111 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.36.tgz",
-      "integrity": "sha512-fZDunw1V0AQS27r5pUN3eOVP7u8YAvyo6vOapdgVRolAu5LgaweP7jncYyLINqIX9ZgWdS5A090bt+ymgaYHsw==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.50.tgz",
+      "integrity": "sha512-N4YqT1jl2tZYNWiLk5gA5BMchHJaG76d65z899DT9UTR4iI6mfqe1QIE+1YLII1x+uE8ohFzBq/aaZ8praLeoA==",
       "dev": true,
       "requires": {
-        "web3-bzz": "1.0.0-beta.36",
-        "web3-core": "1.0.0-beta.36",
-        "web3-eth": "1.0.0-beta.36",
-        "web3-eth-personal": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-shh": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "web3-bzz": "1.0.0-beta.50",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-eth": "1.0.0-beta.50",
+        "web3-eth-personal": "1.0.0-beta.50",
+        "web3-net": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-shh": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.36.tgz",
-      "integrity": "sha512-clDRS/ziboJ5ytnrfxq80YSu9HQsT0vggnT3BkoXadrauyEE/9JNLxRu016jjUxqdkfdv4MgIPDdOS3Bv2ghiw==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.50.tgz",
+      "integrity": "sha512-0jD4/g+apH7t87cA9gXoZpvvVW7OqQtbu+X+olFKPrS9pKbkwfaKPdRwc1BNbjqvrRYN0K7koT9xV+Lzvyah6w==",
       "dev": true,
       "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.37",
-        "underscore": "1.8.3"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "swarm-js": "^0.1.39"
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.36.tgz",
-      "integrity": "sha512-C2QW9CMMRZdYAiKiLkMrKRSp+gekSqTDgZTNvlxAdN1hXn4d9UmcmWSJXOmIHqr5N2ISbRod+bW+qChODxVE3Q==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.50.tgz",
+      "integrity": "sha512-edOHdSnkRREi0vUXXNUsrbkTvXftCDroiF2tEvbPVyiBv0U6/VDYClFdHuZKdrrTRUcn/rUbvBqw8qCt3xgcuQ==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-requestmanager": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.50"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.36.tgz",
-      "integrity": "sha512-gu74l0htiGWuxLQuMnZqKToFvkSM+UFPE7qUuy1ZosH/h2Jd+VBWg6k4CyNYVYfP0hL5x3CN8SBmB+HMowo55A==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.50.tgz",
+      "integrity": "sha512-B1LMrlC9c5HEJYmBWUhsxHdJ78w5YGop/ptF1cFL8cHLwTCQqCFFKLgYUg+dax/554TP1xgJ2w/ArLpnPJ8dBg==",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-eth-iban": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.36.tgz",
-      "integrity": "sha512-dJsP3KkGaqBBSdxfzvLsYPOmVaSs1lR/3oKob/gtUYG7UyTnwquwliAc7OXj+gqRA2E/FHZcM83cWdl31ltdSA==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.50.tgz",
+      "integrity": "sha512-0+L37KDT90DD1fcTye/ZWMyGOLiw0ZxX2vaC8qDSFvAV3scTEuZyEQuR+tCM2aGyUVihy8LdmZwioRwnTXgLwg==",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.36.tgz",
-      "integrity": "sha512-RGIL6TjcOeJTullFLMurChPTsg94cPF6LI763y/sPYtXTDol1vVa+J5aGLp/4WW8v+s+1bSQO6zYq2ZtkbmtEQ==",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "eventemitter3": "1.1.1"
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.36.tgz",
-      "integrity": "sha512-/CHuaMbiMDu1v8ANGYI7yFCnh1GaCWx5pKnUPJf+QTk2xAAw+Bvd97yZJIWPOK5AOPUIzxgwx9Ob/5ln6mTmYA==",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-providers-http": "1.0.0-beta.36",
-        "web3-providers-ipc": "1.0.0-beta.36",
-        "web3-providers-ws": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.36.tgz",
-      "integrity": "sha512-/evyLQ8CMEYXC5aUCodDpmEnmGVYQxaIjiEIfA/85f9ifHkfzP1aOwCAjcsLsJWnwrWDagxSpjCYrDtnNabdEw==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.50.tgz",
+      "integrity": "sha512-q2Jmuy/BCwcKCFjR6kc03hPbdC6sR0n3IhPVg98Sk7ewgRLur/v3lLDz0fQpY4xE6U0XOqrjxwzlqISkOcP5Kw==",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "eventemitter3": "^3.1.0",
+        "lodash": "^4.17.11"
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.36.tgz",
-      "integrity": "sha512-uEa0UnbnNHUB4N2O1U+LsvxzSPJ/w3azy5115IseaUdDaiz6IFFgFfFP3ssauayQNCf7v2F44GXLfPhrNeb/Sw==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.50.tgz",
+      "integrity": "sha512-ojsddEclIdu+C3hfRrLVJK0rcxt2O+Yj7c3b4YEzZQ9+Kd/HaSZfeSpUgKojgmFhUUiCCRTEc2holWtQ+Lx4gQ==",
       "dev": true,
       "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-eth-accounts": "1.0.0-beta.36",
-        "web3-eth-contract": "1.0.0-beta.36",
-        "web3-eth-ens": "1.0.0-beta.36",
-        "web3-eth-iban": "1.0.0-beta.36",
-        "web3-eth-personal": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.36.tgz",
-      "integrity": "sha512-fBfW+7hvA0rxEMV45fO7JU+0R32ayT7aRwG9Cl6NW2/QvhFeME2qVbMIWw0q5MryPZGIN8A6366hKNuWvVidDg==",
-      "dev": true,
-      "requires": {
-        "ethers": "4.0.0-beta.1",
-        "underscore": "1.8.3",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.36.tgz",
-      "integrity": "sha512-MmgIlBEZ0ILLWV4+wfMrbeVVMU/VmQnCpgSDcw7wHKOKu47bKncJ6rVqVsUbC6d9F613Rios+Yj2Ua6SCHtmrg==",
-      "dev": true,
-      "requires": {
-        "any-promise": "1.3.0",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.7",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "eth-lib": "0.2.8",
+        "rxjs": "^6.4.0",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-core-subscriptions": "1.0.0-beta.50",
+        "web3-eth-abi": "1.0.0-beta.50",
+        "web3-eth-accounts": "1.0.0-beta.50",
+        "web3-eth-contract": "1.0.0-beta.50",
+        "web3-eth-ens": "1.0.0-beta.50",
+        "web3-eth-iban": "1.0.0-beta.50",
+        "web3-eth-personal": "1.0.0-beta.50",
+        "web3-net": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
       },
       "dependencies": {
         "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.6",
@@ -4452,165 +4432,198 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
-        }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.36.tgz",
-      "integrity": "sha512-cywqcIrUsCW4fyqsHdOb24OCC8AnBol8kNiptI+IHRylyCjTNgr53bUbjrXWjmEnear90rO0QhAVjLB1a4iEbQ==",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-eth-ens": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.36.tgz",
-      "integrity": "sha512-8ZdD7XoJfSX3jNlZHSLe4G837xQ0v5a8cHCcDcd1IoqoY855X9SrIQ0Xdqia9p4mR1YcH1vgmkXY9/3hsvxS7g==",
-      "dev": true,
-      "requires": {
-        "eth-ens-namehash": "2.0.8",
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-promievent": "1.0.0-beta.36",
-        "web3-eth-abi": "1.0.0-beta.36",
-        "web3-eth-contract": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.36.tgz",
-      "integrity": "sha512-b5AEDjjhOLR4q47Hbzf65zYE+7U7JgCgrUb13RU4HMIGoMb1q4DXaJw1UH8VVHCZulevl2QBjpCyrntecMqqCQ==",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.36"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
-        }
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.36.tgz",
-      "integrity": "sha512-+oxvhojeWh4C/XtnlYURWRR3F5Cg7bQQNjtN1ZGnouKAZyBLoYDVVJ6OaPiveNtfC9RKnzLikn9/Uqc0xz410A==",
-      "dev": true,
-      "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-net": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.36.tgz",
-      "integrity": "sha512-BriXK0Pjr6Hc/VDq1Vn8vyOum4JB//wpCjgeGziFD6jC7Of8YaWC7AJYXje89OckzfcqX1aJyJlBwDpasNkAzQ==",
-      "dev": true,
-      "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-utils": "1.0.0-beta.36"
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.36.tgz",
-      "integrity": "sha512-KLSqMS59nRdpet9B0B64MKgtM3n9wAHTcAHJ03hv79avQNTjHxtjZm0ttcjcFUPpWDgTCtcYCa7tqaYo9Pbeog==",
-      "dev": true,
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.36",
-        "xhr2-cookies": "1.1.0"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.36.tgz",
-      "integrity": "sha512-iEUrmdd2CzoWgp+75/ydom/1IaoLw95qkAzsgwjjZp1waDncHP/cvVGX74+fbUx4hRaPdchyzxCQfNpgLDmNjQ==",
-      "dev": true,
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36"
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.36.tgz",
-      "integrity": "sha512-wAnENuZx75T5ZSrT2De2LOaUuPf2yRjq1VfcbD7+Zd79F3DZZLBJcPyCNVQ1U0fAXt0wfgCKl7sVw5pffqR9Bw==",
-      "dev": true,
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.36",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+        "rxjs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
+            "tslib": "^1.9.0"
           }
         }
       }
     },
-    "web3-shh": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.36.tgz",
-      "integrity": "sha512-bREGHS/WprYFSvGUhyIk8RSpT2Z5SvJOKGBrsUW2nDIMWO6z0Op8E7fzC6GXY2HZfZliAqq6LirbXLgcLRWuPw==",
+    "web3-eth-abi": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.50.tgz",
+      "integrity": "sha512-Nwm1HL3xBbrs43j/9V3gH1CJWWR7jyTDSE7PIkjYVjwgygAjlHPMHzuzGffoFMp2tSQ2DywCGmXAY5I5+vznZw==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.36",
-        "web3-core-method": "1.0.0-beta.36",
-        "web3-core-subscriptions": "1.0.0-beta.36",
-        "web3-net": "1.0.0-beta.36"
+        "@babel/runtime": "^7.3.1",
+        "ethers": "^4.0.27",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.50.tgz",
+      "integrity": "sha512-cUuYxKhymob87zCUYgw7ieZY6aVStMhClocblI3FKNdI1I8dczhdhZ97qMj5iavOganN7/OxLzeji7ksAoNAhg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "lodash": "^4.17.11",
+        "scrypt.js": "0.2.0",
+        "uuid": "3.3.2",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.50.tgz",
+      "integrity": "sha512-X8R1+qIeD4Dbz1RmQa5m3K1suVFigNgd7EFMp6vVC3ULDjt4R6T0cRmFw/x51v3MQoT7s6Yd1KiEWIAt9IYG6w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-core-subscriptions": "1.0.0-beta.50",
+        "web3-eth-abi": "1.0.0-beta.50",
+        "web3-eth-accounts": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.50.tgz",
+      "integrity": "sha512-UnhYcNuSNRBOBcbD5y8cTyRh5ENn65/GfZkxCDXAKBY6sD4GzMZNkD7kq+37/34cnZEzzQPPGd9jLZNLXOklyg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "eth-ens-namehash": "2.0.8",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-eth-abi": "1.0.0-beta.50",
+        "web3-eth-contract": "1.0.0-beta.50",
+        "web3-net": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.50.tgz",
+      "integrity": "sha512-rW5fpUUW3WaToPxBXNnqTfj5dh2BJ+9uognYAfThh2WWR1+EwWZethsKS/PyU6Jn9uA5p/kQoUIP0JKaeBm80Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "bn.js": "4.11.8",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.50.tgz",
+      "integrity": "sha512-52dS24YfJxx/Uy21RKj2m5rjag1kktdy5rY/R9vDwWZRrJkxfDf058CvtRF+QsD7A6QVxkHCZ9YwEWnLCLW9Cw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-net": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-net": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.50.tgz",
+      "integrity": "sha512-T9aBrWYzCeqZTTJlljonTm8x1tEjHT1uBqcdvEYZoyCS1Xxc+zCNBqP4SBfdcfwCeGohhI7bRx9qX1JjYH3cRA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "lodash": "^4.17.11",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
+      }
+    },
+    "web3-providers": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.50.tgz",
+      "integrity": "sha512-p2xtr6N72pdXvND5dLdK1G9T/9qCQiKC2EYDPmimnqvoHWixmM3tlBl042swkHspHHVL60vXPKxB4UDaQE2hWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@types/node": "^10.12.18",
+        "eventemitter3": "3.1.0",
+        "lodash": "^4.17.11",
+        "url-parse": "1.4.4",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+        "xhr2-cookies": "1.1.0"
+      }
+    },
+    "web3-shh": {
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.50.tgz",
+      "integrity": "sha512-a46Gz/YQdF3HJ4XK7rZh6bJiP3IEq+BDAvdxD1jW54yKM2k3RGarOY8hanC1crxKE7E9Q1UUkrp1Vjrj8XSQuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "web3-core": "1.0.0-beta.50",
+        "web3-core-helpers": "1.0.0-beta.50",
+        "web3-core-method": "1.0.0-beta.50",
+        "web3-core-subscriptions": "1.0.0-beta.50",
+        "web3-net": "1.0.0-beta.50",
+        "web3-providers": "1.0.0-beta.50",
+        "web3-utils": "1.0.0-beta.50"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.36.tgz",
-      "integrity": "sha512-7ri74lG5fS2Th0fhYvTtiEHMB1Pmf2p7dQx1COQ3OHNI/CHNEMjzoNMEbBU6FAENrywfoFur40K4m0AOmEUq5A==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.50.tgz",
+      "integrity": "sha512-xGhM/YkepK2x0iMYUl/sws58LzTbodjMGlhZxrCZLZxJ0DoaDyk3UdmZ6aCSCwVTFg4hlVj3doaIhWnwGfhhpQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
+        "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
+        "@types/node": "^10.12.18",
+        "bn.js": "4.11.8",
+        "eth-lib": "0.2.8",
+        "ethjs-unit": "^0.1.6",
+        "lodash": "^4.17.11",
         "number-to-bn": "1.7.0",
         "randomhex": "0.1.5",
-        "underscore": "1.8.3",
         "utf8": "2.1.1"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-          "dev": true
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
         },
         "utf8": {
           "version": "2.1.1",
@@ -4618,6 +4631,17 @@
           "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
           "dev": true
         }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "which": {
@@ -4630,15 +4654,9 @@
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "winston": {
@@ -4810,73 +4828,39 @@
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
       "dev": true
     },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
     "yargs": {
-      "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "cliui": "^3.2.0",
+        "cliui": "^4.0.0",
         "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
         "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
+        "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
+        "yargs-parser": "^9.0.2"
       }
     },
     "yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -28,23 +28,25 @@
   "author": "Gnosis (https://gnosis.pm)",
   "license": "LGPL-3.0",
   "dependencies": {
-    "@gnosis.pm/util-contracts": "^2.0.0-alpha",
-    "canonical-weth": "^1.2.0",
-    "openzeppelin-solidity": "github:gnosis/openzeppelin-solidity#fix-signed-safemath"
+    "@gnosis.pm/util-contracts": "^3.0.0-alpha",
+    "bignumber.js": "^8.1.1",
+    "canonical-weth": "^1.4.0",
+    "openzeppelin-solidity": "^2.2.0"
   },
   "devDependencies": {
     "@digix/tempo": "^0.2.0",
     "@gnosis.pm/truffle-nice-tools": "^1.1.3",
     "babel-eslint": "^10.0.1",
     "cross-env": "^5.2.0",
-    "decimal.js": "^10.0.0",
+    "decimal.js": "^10.1.1",
     "eslint": "^5.7.0",
     "eslint-plugin-babel": "^5.2.1",
     "fs-extra": "^7.0.0",
     "lodash": "^4.17.11",
     "npm-prepublish": "^1.2.3",
     "solhint": "^1.4.1",
-    "truffle": "^4.1.14"
+    "truffle": "^5.0.9",
+    "solc": "^0.5.6"
   },
   "repository": {
     "type": "git",

--- a/test/javascript/digix_tempo.js
+++ b/test/javascript/digix_tempo.js
@@ -1,0 +1,53 @@
+//This is a modified copy of: https://github.com/DigixGlobal/tempo/blob/master/lib/index.js
+// It is not compatible with Web3 v1.0 (https://github.com/DigixGlobal/tempo/issues/5)
+// A pull request has been created https://github.com/DigixGlobal/tempo/pull/4
+// In the mean time, a local modified copy is used.
+
+'use strict';
+
+module.exports = function (web3) {
+  function sendRpc(method, params) {
+    return new Promise(function (resolve) {
+      web3.currentProvider.send({
+        jsonrpc: '2.0',
+        method: method,
+        params: params || [],
+        id: new Date().getTime()
+      }, function (err, res) {
+        resolve(res);
+      });
+    });
+  }
+  function waitUntilBlock(seconds, targetBlock) {
+    return new Promise(function (resolve) {
+      var asyncIterator = function asyncIterator() {
+        return web3.eth.getBlock('latest', function (e, _ref) {
+          var number = _ref.number;
+
+          if (number >= targetBlock - 1) {
+            return sendRpc('evm_increaseTime', [seconds]).then(function () {
+              return sendRpc('evm_mine');
+            }).then(resolve);
+          }
+          return sendRpc('evm_mine').then(asyncIterator);
+        });
+      };
+      asyncIterator();
+    });
+  }
+  function wait() {
+    var seconds = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 20;
+    var blocks = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 1;
+
+    return new Promise(function (resolve) {
+      return web3.eth.getBlock('latest', function (e, _ref2) {
+        var number = _ref2.number;
+
+        resolve(blocks + number);
+      });
+    }).then(function (targetBlock) {
+      return waitUntilBlock(seconds, targetBlock);
+    });
+  }
+  return { wait: wait, waitUntilBlock: waitUntilBlock };
+};

--- a/test/javascript/test_market_makers.js
+++ b/test/javascript/test_market_makers.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const BigNumber = require('bignumber.js')
 
 const utils = require('./utils')
 const { ONE, isClose, lmsrMarginalPrice, getParamFromTxEvent } = utils
@@ -32,11 +33,11 @@ contract('MarketMaker', function(accounts) {
     it.skip('should move price of an outcome to 0 after participants sell lots of that outcome to market maker', async () => {
         // Create event
         const numOutcomes = 2
-        const ipfsHash = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
-        const oracleAddress = getParamFromTxEvent(
+        const ipfsHash = web3.utils.utf8ToHex('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
+        const oracleAddress = await getParamFromTxEvent(
             await centralizedOracleFactory.createCentralizedOracle(ipfsHash),
             'centralizedOracle')
-        const event = getParamFromTxEvent(
+        const event = await getParamFromTxEvent(
             await eventFactory.createCategoricalEvent(etherToken.address, oracleAddress, numOutcomes),
             'categoricalEvent', CategoricalEvent)
 
@@ -44,7 +45,7 @@ contract('MarketMaker', function(accounts) {
         const investor = 0
 
         const feeFactor = 0  // 0%
-        const market = getParamFromTxEvent(
+        const market = await getParamFromTxEvent(
             await standardMarketFactory.createMarket(event.address, lmsrMarketMaker.address, feeFactor,
                 { from: accounts[investor] }),
             'market', StandardMarket)
@@ -53,44 +54,45 @@ contract('MarketMaker', function(accounts) {
         const funding = 1e17
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding.toString())
 
-        await etherToken.approve(market.address, funding, { from: accounts[investor] })
-        await market.fund(funding, { from: accounts[investor] })
+        await etherToken.approve(market.address, funding.toString(), { from: accounts[investor] })
+        await market.fund(funding.toString(), { from: accounts[investor] })
         assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
 
         // User buys all outcomes
         const trader = 1
         const outcome = 1
-        const outcomeToken = OutcomeToken.at(await event.outcomeTokens.call(outcome))
+        const outcomeToken = await OutcomeToken.at(await event.outcomeTokens.call(outcome))
         const tokenCount = 1e18
         const loopCount = 10
 
         await etherToken.deposit({ value: tokenCount * loopCount, from: accounts[trader] })
-        await etherToken.approve(event.address, tokenCount * loopCount, { from: accounts[trader] })
-        await event.buyAllOutcomes(tokenCount * loopCount, { from: accounts[trader] })
+        await etherToken.approve(event.address, (tokenCount * loopCount).toString(), { from: accounts[trader] })
+        await event.buyAllOutcomes((tokenCount * loopCount).toString(), { from: accounts[trader] })
 
         // User sells tokens
         const buyerBalance = await etherToken.balanceOf.call(accounts[trader])
         let profit, outcomeTokenAmounts
         for(let i of _.range(loopCount)) {
             // Calculate profit for selling tokens
-            outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? -tokenCount : 0)
+            outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? (-tokenCount).toString() : 0)
             profit = (await lmsrMarketMaker.calcNetCost.call(market.address, outcomeTokenAmounts)).neg()
             if(profit == 0)
                 break
 
             // Selling tokens
-            await outcomeToken.approve(market.address, tokenCount, { from: accounts[trader] })
-            assert.equal(getParamFromTxEvent(
+            await outcomeToken.approve(market.address, tokenCount.toString(), { from: accounts[trader] })
+            assert.equal((await getParamFromTxEvent(
                 await market.trade(outcomeTokenAmounts, profit.neg(), { from: accounts[trader] }), 'outcomeTokenNetCost'
-            ).neg().valueOf(), profit.valueOf())
+            )).neg().valueOf(), profit.toString())
 
             let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))
             let expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-            let actual = (await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome)).div(ONE)
+            let actual = new BigNumber((await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome.toString())))
+                .div(ONE.toString())
             assert(
-                isClose(actual, expected),
+                isClose(actual, expected, relTol=1e-3, absTol=1e-9),
                 `Marginal price calculation is off for iteration ${i}:\n` +
                 `        funding: ${funding}\n` +
                 `        net outcome tokens sold: ${netOutcomeTokensSold}\n` +
@@ -101,7 +103,7 @@ contract('MarketMaker', function(accounts) {
         // Selling of tokens is worth less than 1 Wei
         assert.equal(profit, 0)
         // User's Ether balance increased
-        assert.isAbove(await etherToken.balanceOf.call(accounts[trader]), buyerBalance)
+        assert(BigNumber(await etherToken.balanceOf.call(accounts[trader]).valueOf()).gte(buyerBalance))
     })
 
     it.skip('should move price of an outcome to 1 after participants buy lots of that outcome from market maker', async () => {
@@ -112,27 +114,27 @@ contract('MarketMaker', function(accounts) {
         ]) {
             // Create event
             const numOutcomes = 2
-            const ipfsHash = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
-            const oracleAddress = getParamFromTxEvent(
+            const ipfsHash = web3.utils.utf8ToHex('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
+            const oracleAddress = await getParamFromTxEvent(
                 await centralizedOracleFactory.createCentralizedOracle(ipfsHash),
                 'centralizedOracle')
-            const event = getParamFromTxEvent(
+            const event = await getParamFromTxEvent(
                 await eventFactory.createCategoricalEvent(etherToken.address, oracleAddress, numOutcomes),
                 'categoricalEvent', CategoricalEvent)
 
             // Create market
             const feeFactor = 0  // 0%
-            const market = getParamFromTxEvent(
+            const market = await getParamFromTxEvent(
                 await standardMarketFactory.createMarket(event.address, lmsrMarketMaker.address, feeFactor,
                     { from: accounts[investor] }),
                 'market', StandardMarket)
 
             // Fund market
             await etherToken.deposit({ value: funding, from: accounts[investor] })
-            assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+            assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding.toString())
 
-            await etherToken.approve(market.address, funding, { from: accounts[investor] })
-            await market.fund(funding, { from: accounts[investor] })
+            await etherToken.approve(market.address, funding.toString(), { from: accounts[investor] })
+            await market.fund(funding.toString(), { from: accounts[investor] })
             assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
 
             // User buys ether tokens
@@ -145,18 +147,18 @@ contract('MarketMaker', function(accounts) {
             let cost, outcomeTokenAmounts
             for(let i of _.range(loopCount)) {
                 // Calculate cost of buying tokens
-                outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount : 0)
+                outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome.toString() ? tokenCount.toString() : 0)
                 cost = await lmsrMarketMaker.calcNetCost.call(market.address, outcomeTokenAmounts)
 
                 // Buying tokens
-                await etherToken.approve(market.address, tokenCount, { from: accounts[trader] })
-                assert.equal(getParamFromTxEvent(
-                    await market.trade(outcomeTokenAmounts, cost, { from: accounts[trader] }), 'outcomeTokenNetCost'
-                ).valueOf(), cost.valueOf())
+                await etherToken.approve(market.address, tokenCount.toString(), { from: accounts[trader] })
+                assert.equal(await getParamFromTxEvent(
+                    await market.trade(outcomeTokenAmounts, cost.toString(), { from: accounts[trader] }), 'outcomeTokenNetCost'
+                ).valueOf(), cost.toString())
 
                 let netOutcomeTokensSold = await Promise.all(_.range(numOutcomes).map((j) => market.netOutcomeTokensSold(j)))
                 let expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-                let actual = (await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome)).div(ONE)
+                let actual = new BigNumber(await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome.toString())).div(ONE.toString())
                 assert(
                     isClose(actual, expected) || expected.toString() == 'NaN',
                     `Marginal price calculation is off for iteration ${i}:\n` +
@@ -168,18 +170,18 @@ contract('MarketMaker', function(accounts) {
             }
 
             // Price is equal to 1
-            assert.equal(cost, tokenCount)
+            assert.equal(cost.toString(), 1)
         }
     })
 
     it('should allow buying and selling outcome tokens in the same transaction', async () => {
         // Create event
         const numOutcomes = 4
-        const ipfsHash = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
-        const oracleAddress = getParamFromTxEvent(
+        const ipfsHash = web3.utils.utf8ToHex('QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG')
+        const oracleAddress = await getParamFromTxEvent(
             await centralizedOracleFactory.createCentralizedOracle(ipfsHash),
             'centralizedOracle')
-        const event = getParamFromTxEvent(
+        const event = await getParamFromTxEvent(
             await eventFactory.createCategoricalEvent(etherToken.address, oracleAddress, numOutcomes),
             'categoricalEvent', CategoricalEvent)
 
@@ -187,13 +189,13 @@ contract('MarketMaker', function(accounts) {
         const investor = 5
 
         const feeFactor = 0  // 0%
-        const market = getParamFromTxEvent(
+        const market = await getParamFromTxEvent(
             await standardMarketFactory.createMarket(event.address, lmsrMarketMaker.address, feeFactor,
                 { from: accounts[investor] }),
             'market', StandardMarket)
 
         // Fund market
-        const funding = 1e18
+        const funding = 1e18.toString()
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
         assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
@@ -207,28 +209,31 @@ contract('MarketMaker', function(accounts) {
         const initialWETH9Count = 10e18
 
         // User buys all outcomes
-        await etherToken.deposit({ value: initialOutcomeTokenCount + initialWETH9Count, from: accounts[trader] })
-        await etherToken.approve(event.address, initialOutcomeTokenCount, { from: accounts[trader] })
-        await event.buyAllOutcomes(initialOutcomeTokenCount, { from: accounts[trader] })
+        await etherToken.deposit({ value: (initialOutcomeTokenCount + initialWETH9Count).toString(), from: accounts[trader] })
+        await etherToken.approve(event.address, initialOutcomeTokenCount.toString(), { from: accounts[trader] })
+        await event.buyAllOutcomes(initialOutcomeTokenCount.toString(), { from: accounts[trader] })
 
         // User trades with the market
         const tradeValues = [5e17, -1e18, -1e17, 2e18]
-        const cost = await lmsrMarketMaker.calcNetCost.call(market.address, tradeValues)
+        const tradeValuesAsStrings = [5e17.toString(), (-1e18).toString(), (-1e17).toString(), 2e18.toString()]
+        const cost = await lmsrMarketMaker.calcNetCost.call(market.address, tradeValuesAsStrings)
+
         if(cost.gt(0)) await etherToken.approve(market.address, cost, { from: accounts[trader] })
 
         const outcomeTokens = await Promise.all(_.range(numOutcomes).map(i => event.outcomeTokens.call(i).then(tokenAddr => OutcomeToken.at(tokenAddr))))
         await Promise.all(tradeValues.map((v, i) => [v, i]).filter(([v]) => v < 0).map(([v, i]) =>
-            outcomeTokens[i].approve(market.address, -v, { from: accounts[trader] })))
+            outcomeTokens[i].approve(market.address, (-v).toString(), { from: accounts[trader] })))
 
-        assert.equal(getParamFromTxEvent(
-            await market.trade(tradeValues, cost, { from: accounts[trader] }), 'outcomeTokenNetCost'
-        ), cost.valueOf())
+        assert.equal(await getParamFromTxEvent(
+            await market.trade(tradeValuesAsStrings, cost, { from: accounts[trader] }), 'outcomeTokenNetCost'
+        ), cost.toString())
 
         // All state transitions associated with trade have been performed
         for(let [tradeValue, i] of tradeValues.map((v, i) => [v, i])) {
-            assert.equal(await outcomeTokens[i].balanceOf.call(accounts[trader]), initialOutcomeTokenCount + tradeValue)
+            assert.equal(await outcomeTokens[i].balanceOf.call(accounts[trader]), (initialOutcomeTokenCount + tradeValue).toString())
         }
-
-        assert.equal(await etherToken.balanceOf.call(accounts[trader]), initialWETH9Count - cost.valueOf())
+        
+        assert.equal(await etherToken.balanceOf.call(accounts[trader]), 
+            new BigNumber(initialWETH9Count).minus(cost).toString() )
     })
 })

--- a/test/javascript/test_market_makers.js
+++ b/test/javascript/test_market_makers.js
@@ -92,7 +92,7 @@ contract('MarketMaker', function(accounts) {
             let actual = new BigNumber((await lmsrMarketMaker.calcMarginalPrice.call(market.address, outcome.toString())))
                 .div(ONE.toString())
             assert(
-                isClose(actual, expected, relTol=1e-3, absTol=1e-9),
+                isClose(actual, expected, 1e-3, 1e-9),
                 `Marginal price calculation is off for iteration ${i}:\n` +
                 `        funding: ${funding}\n` +
                 `        net outcome tokens sold: ${netOutcomeTokensSold}\n` +

--- a/truffle.js
+++ b/truffle.js
@@ -31,12 +31,17 @@ const config = {
             host: "localhost",
             port: 8545,
             network_id: "437894314312",
-        },
+        }
     },
     mocha: {
         enableTimeouts: false,
         grep: process.env.TEST_GREP
-    }
+    },
+	compilers: {
+		solc: {
+			version: "0.5.6"
+		}
+	}
 }
 
 const _ = require('lodash')


### PR DESCRIPTION
 - Update to Truffle v5.0.9
 - Update .sol files for the breaking changes of Solidity v0.5
 - Explicitly configure Truffle to use solc v0.5.6
(because some updated dependencies require solc version above the current default v0.5.0 version that came with current Truffle version)
 - Add solc v0.5.6 to package.json
 - Add compiler configuration to truffle.js
 - Update js test files to work with Web3 v1.0.
Updates are mainly:
        - Use BigNumber.js and `.toString()` instead of `.valueOf()` because of issues with BN.js: https://github.com/ethereum/web3.js/issues/2171
        - Use async / await with Web3 because all Web3 v1.0 calls are asynchronous
 - Update Open Zeppelin to v2.2.0 and Canonical WEth to v1.4
 - Configure Travis to use Node 10 and 9 (Truffle v5 does not work with Node 7)